### PR TITLE
Update deatch addon

### DIFF
--- a/deatchConsumerAddon.sh
+++ b/deatchConsumerAddon.sh
@@ -23,83 +23,79 @@ usage() {
 EOF
 }
 
-if [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
-  usage
-  exit 0
-fi
+deatchAddon () {
+  echo -e "${Green}Deatach addon script started for Consumer ${EndColor}"$1
 
-if [[ "${2}" != "-dev" ]] && [[ "${2}" != "-qe" ]] && [[ "${2}" != "" ]]; then
-  usage
-  exit 0
-fi
+  echo -e "\n${Cyan}Scaling down the addon-operator-manager${EndColor}"
+  kubectl scale deployment addon-operator-manager -n openshift-addon-operator --replicas 0
 
-echo -e "${Green}Deatach addon script started${EndColor}"
+  # removing owner ref from namespace and subscription
+  echo -e "\n${Cyan}Deleting addoninstance from openshift-storage namespace${EndColor}"
+  kubectl delete addoninstance addon-instance -n openshift-storage --cascade='orphan'
 
-echo -e "\n${Cyan}Scaling down the addon-operator-manager${EndColor}"
-kubectl scale deployment addon-operator-manager -n openshift-addon-operator --replicas 0
+  echo -e "${Cyan}Patching the addon ocs-consumer$2 to remove finalizers${EndColor}"
+  kubectl patch addon ocs-consumer$2 -p '{"metadata":{"finalizers":null}}' --type=merge
 
-# removing owner ref from namespace and subscription
-echo -e "\n${Cyan}Deleting addoninstance from openshift-storage namespace${EndColor}"
-kubectl delete addoninstance addon-instance -n openshift-storage --cascade='orphan'
+  echo -e "\n${Cyan}Deleting addon ocs-consumer$2 ${EndColor}"
+  kubectl delete addon ocs-consumer$2 --cascade='orphan'
 
-echo -e "${Cyan}Patching the addon ocs-consumer$2 to remove finalizers${EndColor}"
-kubectl patch addon ocs-consumer$2 -p '{"metadata":{"finalizers":null}}' --type=merge
+  echo -e "\n${Cyan}Scaling down the ocs-osd-deployer${EndColor}"
+  kubectl scale deployment ocs-osd-controller-manager -n openshift-storage --replicas=0
 
-echo -e "\n${Cyan}Deleting addon ocs-consumer$2 ${EndColor}"
-kubectl delete addon ocs-consumer$2 --cascade='orphan'
+  echo -e "\n${Cyan}Uninstalling consumer addon${EndColor}"
 
-echo -e "\n${Cyan}Scaling down the ocs-osd-deployer${EndColor}"
-kubectl scale deployment ocs-osd-controller-manager -n openshift-storage --replicas=0
+  ocm delete /api/clusters_mgmt/v1/clusters/$1/addons/ocs-consumer$2
 
-echo -e "\n${Cyan}Uninstalling consumer addon${EndColor}"
+  while true
+  do
 
-ocm delete /api/clusters_mgmt/v1/clusters/$1/addons/ocs-consumer$2
+    state=$(ocm get /api/clusters_mgmt/v1/clusters/$1/addons | jq  -r '. | select(.items != null) | .items[] | select(.id == "ocs-consumer'$2'") | .state')
 
-while true
-do
+    echo -e "${Blue}waiting for addon to be uninstalled current state is ${EndColor}"$state
+    if [[ $state == "deleting" ]];
+    then
+        break
+    fi
+    sleep 60
+  done
 
-  state=$(ocm get /api/clusters_mgmt/v1/clusters/$1/addons | jq  -r '. | select(.items != null) | .items[] | select(.id == "ocs-consumer'$2'") | .state')
+  echo -e "\n${Cyan}Deleting ocs-osd-deployer-csv${EndColor}"
+  kubectl delete csv $(kubectl get csv -n openshift-storage | grep ocs-osd | awk '{print $1}') -n openshift-storage
 
-  echo -e "${Blue}waiting for addon to be uninstalled current state is ${EndColor}"$state
-  if [[ $state == "deleting" ]];
-  then
-      break
-  fi
-  sleep 60
-done
+}
 
-echo -e "\n${Cyan}Deleting ocs-osd-deployer-csv${EndColor}"
-kubectl delete csv $(kubectl get csv -n openshift-storage | grep ocs-osd | awk '{print $1}') -n openshift-storage
 
-while true
-do
+deleteResources () {
+  while true
+  do
 
-  state=$(ocm get /api/clusters_mgmt/v1/clusters/$1/addons | jq  -r '. | select(.items != null) | .items[] | select(.id == "ocs-consumer'$2'") | .state')
+    state=$(ocm get /api/clusters_mgmt/v1/clusters/$1/addons | jq  -r '. | select(.items != null) | .items[] | select(.id == "ocs-consumer'$2'") | .state')
 
-  echo -e "${Blue}waiting for addon to be uninstalled current state is ${EndColor}"$state
-  if [ -z "$state" ];
-  then
-      break
-  fi
-  sleep 60
-done
+    echo -e "${Blue}waiting for addon to be uninstalled current state is ${EndColor}"$state
+    if [ -z "$state" ];
+    then
+        break
+    fi
+    sleep 60
+  done
 
-echo -e "\n${Cyan}Uninstalled ocs-consumer$2 addon${EndColor}"
+  echo -e "\n${Cyan}Uninstalled ocs-consumer$2 addon${EndColor}"
 
-echo -e "\n${Cyan}Deleting addon subscription${EndColor}"
-kubectl delete subs addon-ocs-consumer$2 -n openshift-storage
+  echo -e "\n${Cyan}Deleting addon subscription${EndColor}"
+  kubectl delete subs addon-ocs-consumer$2 -n openshift-storage
 
-echo -e "${Cyan}Patching the managedocs to remove finalizers${EndColor}"
-kubectl patch managedocs managedocs -n openshift-storage -p '{"metadata":{"finalizers":null}}' --type=merge
-echo -e "\n${Cyan}Deleting managedocs CR${EndColor}"
-kubectl delete managedocs managedocs -n openshift-storage --cascade='orphan'
+  echo -e "${Cyan}Patching the managedocs to remove finalizers${EndColor}"
+  kubectl patch managedocs managedocs -n openshift-storage -p '{"metadata":{"finalizers":null}}' --type=merge
+  echo -e "\n${Cyan}Deleting managedocs CR${EndColor}"
+  kubectl delete managedocs managedocs -n openshift-storage --cascade='orphan'
 
-echo -e "\n${Cyan}Deleting addon deletion configmap${EndColor}"
-kubectl delete configmap ocs-consumer$2 -n openshift-storage
+  echo -e "\n${Cyan}Deleting addon deletion configmap${EndColor}"
+  kubectl delete configmap ocs-consumer$2 -n openshift-storage
 
-# echo -e "\nDeleting addon catalog source"
-# kubectl delete catsrc addon-ocs-consumer-catalog -n openshift-storage
+  # echo -e "\nDeleting addon catalog source"
+  # kubectl delete catsrc addon-ocs-consumer-catalog -n openshift-storage
 
-echo -e "\n${Cyan}Scaling up the addon-operator-manager${EndColor}"
-kubectl scale deployment addon-operator-manager -n openshift-addon-operator --replicas 1
-echo -e "${Green}Deatach addon script completed!${EndColor}\n"
+  echo -e "\n${Cyan}Scaling up the addon-operator-manager${EndColor}"
+  kubectl scale deployment addon-operator-manager -n openshift-addon-operator --replicas 1
+  echo -e "${Green}Deatach addon script completed for Consumer ${EndColor}"$1"\n"
+}


### PR DESCRIPTION
Currently deatch addon takes 20 mins per consumer, the deletion of addon from ocm api takes the most time, split the deatch addon into two functions such that all the consumer addons starts detaching all at once, this will reduce the total time taken by the script. If we call the deatchAddon before even migrating providers, we won't need to wait 20 mins for deatch addon, as provider script also takes ~15mins